### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -2,4 +2,6 @@ version: 2.1
 
 description: >
   Execute VMware Cloud Automation Services: Code Stream pipelines as a part of CircleCI jobs
-  Repo: https://github.com/vmwarecas/circleciorb-codestream
+display:
+  home_url: https://cloud.vmware.com/code-stream
+  source_url: https://github.com/vmwarecas/circleciorb-codestream


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.